### PR TITLE
Fixes #13, fixes #12:

### DIFF
--- a/deepsampler-persistence-json/src/main/java/de/ppi/deepsampler/persistence/json/JsonRecorder.java
+++ b/deepsampler-persistence-json/src/main/java/de/ppi/deepsampler/persistence/json/JsonRecorder.java
@@ -42,7 +42,7 @@ public class JsonRecorder extends JsonOperator {
             if (persistentResource instanceof PersistentFile) {
                 // CREATE PARENT DIR IF NECESSARY
                 final Path parentPath = ((PersistentFile) persistentResource).getFilePath().getParent();
-                if (!Files.exists(parentPath)) {
+                if (parentPath != null && !Files.exists(parentPath)) {
                     Files.createDirectories(parentPath);
                 }
             }

--- a/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/SamplerBeanFactory.java
+++ b/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/SamplerBeanFactory.java
@@ -5,8 +5,11 @@
 
 package de.ppi.deepsampler.persistence;
 
+import de.ppi.deepsampler.persistence.bean.ext.CollectionMapExtension;
 import de.ppi.deepsampler.persistence.bean.ext.JavaTimeExtension;
 import de.ppi.deepsampler.persistence.bean.PersistentBeanFactory;
+
+import java.util.List;
 
 public class SamplerBeanFactory {
 
@@ -17,6 +20,7 @@ public class SamplerBeanFactory {
     static PersistentBeanFactory create() {
         PersistentBeanFactory persistentBeanFactory = new PersistentBeanFactory();
         persistentBeanFactory.addExtension(new JavaTimeExtension());
+        persistentBeanFactory.addExtension(new CollectionMapExtension());
         return persistentBeanFactory;
     }
 }

--- a/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/api/PersistentSampleManager.java
+++ b/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/api/PersistentSampleManager.java
@@ -43,8 +43,15 @@ public class PersistentSampleManager {
         return this;
     }
 
-    public void addBeanExtension(final BeanFactoryExtension beanFactoryExtension) {
+    /**
+     * Add a {@link BeanFactoryExtension} to the sample manager.
+     *
+     * @param beanFactoryExtension {@link BeanFactoryExtension}
+     * @return this
+     */
+    public PersistentSampleManager addBeanExtension(final BeanFactoryExtension beanFactoryExtension) {
         persistentSamplerContext.addBeanFactoryExtension(beanFactoryExtension);
+        return this;
     }
 
     /**

--- a/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/bean/PersistentBeanFactory.java
+++ b/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/bean/PersistentBeanFactory.java
@@ -149,9 +149,9 @@ public class PersistentBeanFactory {
 
             if (fieldValue != null) {
                 if (isObjectArray(field.getType())) {
-                    fieldValue = toBean((Object[]) fieldValue);
+                    fieldValue = toBeanIfNecessary((Object[]) fieldValue);
                 } else if (!isPrimitive(field.getType()) && !field.getType().isArray()) {
-                    fieldValue = toBean(fieldValue);
+                    fieldValue = toBeanIfNecessary(fieldValue);
                 }
             }
             valuesForBean.put(keyForField, fieldValue);
@@ -243,10 +243,10 @@ public class PersistentBeanFactory {
                 .collect(Collectors.toList());
     }
 
-    public PersistentBean[] toBean(final Object[] objects) {
-        final PersistentBean[] persistentBeans = new DefaultPersistentBean[objects.length];
+    public Object[] toBeanIfNecessary(final Object[] objects) {
+        final Object[] persistentBeans = new Object[objects.length];
         for (int i = 0; i < objects.length; ++i) {
-            persistentBeans[i] = toBean(objects[i]);
+            persistentBeans[i] = toBeanIfNecessary(objects[i]);
         }
         return persistentBeans;
     }

--- a/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/bean/ext/BeanFactoryExtension.java
+++ b/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/bean/ext/BeanFactoryExtension.java
@@ -8,10 +8,76 @@ package de.ppi.deepsampler.persistence.bean.ext;
 
 import de.ppi.deepsampler.persistence.model.PersistentBean;
 
+/**
+ * <p>
+ * Interface for extensions of the {@link de.ppi.deepsampler.persistence.bean.PersistentBeanFactory}.
+ * The PersistentBeanFactory is responsible for creating a generic data-structure for
+ * java beans. Also it will convert back this data-structures to the original objects.
+ * The reason for this is to omit the type information when serializing objects.
+ * </p>
+ *
+ * <br>
+ *
+ * <p>
+ * As this is a highly generic and complicated process deepsampler offers extensions
+ * for this BeanFactory the {@link BeanFactoryExtension}. To add an extension you have
+ * to specifiy it when recording/loading samples with {@link de.ppi.deepsampler.persistence.api.PersistentSampler}
+ * ({@link de.ppi.deepsampler.persistence.api.PersistentSampleManager#addBeanExtension(BeanFactoryExtension)}.
+ * </p>
+ * <br>
+ * <p>
+ * The extension will be used for all processed objects (including embedded objects).
+ * </p>
+ * <br>
+ * <p>
+ * When you write an extension you firstly have to define which for which typed you
+ * want to extend the behavior of the original BeanFactory. For this purpose you
+ * can use {@link #isProcessable(Class)}.
+ * </p>
+ * <p>
+ * After this every bean with the specified type will be processed within the extension. Now
+ * you can implement custom conversion logic yourBean -> generic data-structure (
+ * {@link #toBean(Object)} and generic data-structure -> yourBean ({@link #ofBean(PersistentBean, Class)}).
+ * </p>
+ * <p>
+ * Besides this you can also make the BeanFactory skip the processing of all types for which
+ * your implementation {@link #isProcessable(Class)} will return true. So you can exclude
+ * some types from being processed by the factory.
+ * </p>
+ */
 public interface BeanFactoryExtension {
+
+    /**
+     * Describe the target types you want to process withing this extension.
+     *
+     * @param beanCls the class of the bean for which it will be
+     * @return true when the class should be processed within this extension, false otherwise
+     */
     boolean isProcessable(Class<?> beanCls);
+
+    /**
+     * Skip the conversion of all beans of the given type.
+     *
+     * @param beanCls the type you might want to skip
+     * @return true if the class should get skipped
+     */
     boolean skip(Class<?> beanCls);
 
+    /**
+     * Conversion logic for the type you defined to process and not to skip.
+     *
+     * @param bean the bean
+     * @return the generic data-structure for the bean
+     */
     PersistentBean toBean(Object bean);
+
+    /**
+     * Conversion logic for the generic data-structure to the processed bean type.
+     *
+     * @param bean the generic bean
+     * @param target the target class
+     * @param <T> type of the original bean
+     * @return original bean
+     */
     <T> T ofBean(PersistentBean bean, Class<T> target);
 }

--- a/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/bean/ext/CollectionMapExtension.java
+++ b/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/bean/ext/CollectionMapExtension.java
@@ -1,0 +1,18 @@
+package de.ppi.deepsampler.persistence.bean.ext;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class CollectionMapExtension extends StandardBeanFactoryExtension {
+
+    @Override
+    public boolean isProcessable(Class<?> beanCls) {
+        return Collection.class.isAssignableFrom(beanCls) ||
+                Map.class.isAssignableFrom(beanCls);
+    }
+
+    @Override
+    public boolean skip(Class<?> beanCls) {
+        return isProcessable(beanCls);
+    }
+}

--- a/deepsampler-persistence/src/test/java/de/ppi/deepsampler/persistence/SamplerBeanFactoryTest.java
+++ b/deepsampler-persistence/src/test/java/de/ppi/deepsampler/persistence/SamplerBeanFactoryTest.java
@@ -1,0 +1,36 @@
+package de.ppi.deepsampler.persistence;
+
+import de.ppi.deepsampler.persistence.bean.PersistentBeanFactory;
+import de.ppi.deepsampler.persistence.model.PersistentBean;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SamplerBeanFactoryTest {
+
+    @Test
+    void testImmutableCollectionBean() {
+        // GIVEN
+        final CollectionBean bean = new CollectionBean();
+        List<String> listOfStrings = new ArrayList<>();
+        listOfStrings.add("AB");
+        listOfStrings.add("CD");
+        bean.collectionOfStrings = Collections.unmodifiableList(listOfStrings);
+
+        // WHEN
+        PersistentBean persistentBean = SamplerBeanFactory.create().toBean(bean);
+
+        // THEN
+        assertEquals(bean.collectionOfStrings, persistentBean.getValue("0$collectionOfStrings"));
+    }
+
+    private static class CollectionBean {
+        Collection<String> collectionOfStrings;
+    }
+
+}

--- a/deepsampler-persistence/src/test/java/de/ppi/deepsampler/persistence/bean/PersistentBeanFactoryTest.java
+++ b/deepsampler-persistence/src/test/java/de/ppi/deepsampler/persistence/bean/PersistentBeanFactoryTest.java
@@ -300,7 +300,7 @@ class PersistentBeanFactoryTest {
     void testImmutableCollectionBean() {
         // GIVEN
         final CollectionBean bean = new CollectionBean();
-        bean.collectionOfStrings = List.of("AB", "CD");
+        bean.collectionOfStrings = Arrays.asList("AB", "CD");
 
         // WHEN
         PersistentBean persistentBean = new PersistentBeanFactory().toBean(bean);

--- a/deepsampler-persistence/src/test/java/de/ppi/deepsampler/persistence/bean/PersistentBeanFactoryTest.java
+++ b/deepsampler-persistence/src/test/java/de/ppi/deepsampler/persistence/bean/PersistentBeanFactoryTest.java
@@ -11,10 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -297,6 +294,23 @@ class PersistentBeanFactoryTest {
         // THEN
         assertEquals("ME AND ALL", testBean.getAbc());
         assertEquals("ME AND MORE", testBean.getDef());
+    }
+
+    @Test
+    void testImmutableCollectionBean() {
+        // GIVEN
+        final CollectionBean bean = new CollectionBean();
+        bean.collectionOfStrings = List.of("AB", "CD");
+
+        // WHEN
+        PersistentBean persistentBean = new PersistentBeanFactory().toBean(bean);
+
+        // THEN
+        assertNotNull(persistentBean.getValue("0$collectionOfStrings"));
+    }
+
+    private static class CollectionBean {
+        Collection<String> collectionOfStrings;
     }
 
     private static class ImmutableSimpleTestBean {

--- a/deepsampler-persistence/src/test/java/de/ppi/deepsampler/persistence/bean/ext/CollectionMapExtensionTest.java
+++ b/deepsampler-persistence/src/test/java/de/ppi/deepsampler/persistence/bean/ext/CollectionMapExtensionTest.java
@@ -1,0 +1,72 @@
+package de.ppi.deepsampler.persistence.bean.ext;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CollectionMapExtensionTest {
+
+    @Test
+    void testArrayListProcessableAndSkipped() {
+        // GIVEN
+        BeanFactoryExtension extension = new CollectionMapExtension();
+        final Class<ArrayList> beanCls = ArrayList.class;
+
+        // WHEN
+        boolean isProcessable = extension.isProcessable(beanCls);
+        boolean isSkip = extension.skip(beanCls);
+
+        // THEN
+        assertTrue(isProcessable);
+        assertTrue(isSkip);
+    }
+
+    @Test
+    void testHashSetProcessableAndSkipped() {
+        // GIVEN
+        BeanFactoryExtension extension = new CollectionMapExtension();
+        final Class<HashSet> beanCls = HashSet.class;
+
+        // WHEN
+        boolean isProcessable = extension.isProcessable(beanCls);
+        boolean isSkip = extension.skip(beanCls);
+
+        // THEN
+        assertTrue(isProcessable);
+        assertTrue(isSkip);
+    }
+
+    @Test
+    void testStringProcessableAndSkipped() {
+        // GIVEN
+        BeanFactoryExtension extension = new CollectionMapExtension();
+        final Class<String> beanCls = String.class;
+
+        // WHEN
+        boolean isProcessable = extension.isProcessable(beanCls);
+        boolean isSkip = extension.skip(beanCls);
+
+        // THEN
+        assertFalse(isProcessable);
+        assertFalse(isSkip);
+    }
+
+    @Test
+    void testMapProcessableAndSkipped() {
+        // GIVEN
+        BeanFactoryExtension extension = new CollectionMapExtension();
+        final Class<HashMap> beanCls = HashMap.class;
+
+        // WHEN
+        boolean isProcessable = extension.isProcessable(beanCls);
+        boolean isSkip = extension.skip(beanCls);
+
+        // THEN
+        assertTrue(isProcessable);
+        assertTrue(isSkip);
+    }
+}


### PR DESCRIPTION
* Collection and Map implementations will be ignored by the PersistentBeanFactory
* There is no need anymore to define a parent path when reording files.