### PR TITLE
Fixes #56: 

### DIFF
--- a/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/bean/ext/JavaTimeExtension.java
+++ b/deepsampler-persistence/src/main/java/de/ppi/deepsampler/persistence/bean/ext/JavaTimeExtension.java
@@ -7,12 +7,14 @@ package de.ppi.deepsampler.persistence.bean.ext;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Date;
 
 public class JavaTimeExtension extends StandardBeanFactoryExtension {
 
     @Override
     public boolean isProcessable(Class<?> beanCls) {
-        return LocalDateTime.class.isAssignableFrom(beanCls) || LocalDate.class.isAssignableFrom(beanCls);
+        return LocalDateTime.class.isAssignableFrom(beanCls) || LocalDate.class.isAssignableFrom(beanCls)
+                || Date.class.isAssignableFrom(beanCls);
     }
 
     @Override

--- a/deepsampler-persistence/src/test/java/de/ppi/deepsampler/persistence/SamplerBeanFactoryTest.java
+++ b/deepsampler-persistence/src/test/java/de/ppi/deepsampler/persistence/SamplerBeanFactoryTest.java
@@ -3,6 +3,7 @@ package de.ppi.deepsampler.persistence;
 import de.ppi.deepsampler.persistence.model.PersistentBean;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,6 +27,24 @@ class SamplerBeanFactoryTest {
 
         // THEN
         assertEquals(bean.collectionOfStrings, persistentBean.getValue("0$collectionOfStrings"));
+    }
+
+    @Test
+    void testTimestampSql() {
+        // GIVEN
+        Timestamp ts =  new Timestamp(1L);
+        final TimestampBean timestampBean = new TimestampBean();
+        timestampBean.timestamp = ts;
+
+        // WHEN
+        PersistentBean persistentBean = SamplerBeanFactory.create().toBean(timestampBean);
+
+        // THEN
+        assertEquals(ts, persistentBean.getValue("0$timestamp"));
+    }
+
+    private static class TimestampBean {
+        Timestamp timestamp;
     }
 
     private static class CollectionBean {


### PR DESCRIPTION
All util.Date (+ subclasses) objects won't be processed by the BeanFactory to make jackson apply the correct date-serializer.